### PR TITLE
Fix the testserver backend.

### DIFF
--- a/pkg/cli/testserver.go
+++ b/pkg/cli/testserver.go
@@ -41,7 +41,7 @@ func NewTestserverCommand() *cobra.Command {
 				return ExitErrorf(EX_CONFIG, "invalid TLS configuration: %s", err)
 			}
 
-			auth.RegisterServer(srv, &auth.Htpasswd{Log: log})
+			auth.RegisterServer(srv, &auth.Testserver{Log: log})
 
 			log.Info("started serving", "address", mustString(cmd.Flags().GetString("address")))
 			return auth.RunServer(listener, srv, ctrl.SetupSignalHandler())


### PR DESCRIPTION
The `testserver` subcommand was running the `Htpasswd` backend rather
than the `Testserver` backend.

Signed-off-by: James Peach <jpeach@vmware.com>