### PR TITLE
htpasswd-deployment: Increase mem limit to 90 Mi

### DIFF
--- a/config/htpasswd/deployment.yaml
+++ b/config/htpasswd/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 90Mi
       volumes:
       - name: tls
         secret:


### PR DESCRIPTION
The pod was OOMKilled with 30 Mi, so increase the limit to 90 Mi.