### PR TITLE
enable arm64 binaries/images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
   - CGO_ENABLED=0
   goarch:
   - amd64
+  - arm64
   goos:
   - linux
   - darwin


### PR DESCRIPTION
I'd like to use my M1 mac to develop and the Contour E2E tests need an auth server with arm64. I "think" this is enough to enable? 

Signed-off-by: Steve Sloka <slokas@vmware.com>
