### PR TITLE
Support new version of cert-manager

### DIFF
--- a/config/default/issuer.yaml
+++ b/config/default/issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned

--- a/config/htpasswd/certificate.yaml
+++ b/config/htpasswd/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: htpasswd

--- a/config/oidc/certificate.yaml
+++ b/config/oidc/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: oidc

--- a/config/testserver/certificate.yaml
+++ b/config/testserver/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: testserver


### PR DESCRIPTION
Fixed `apiVersion` of cert-manager to a newer version.