### PR TITLE
change minimum TLS version to 1.2

### DIFF
--- a/pkg/auth/server.go
+++ b/pkg/auth/server.go
@@ -117,7 +117,7 @@ func NewServerCredentials(certPath string, keyPath string, caPath string) (crede
 	}
 
 	return credentials.NewTLS(&tls.Config{
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{srv},
 		RootCAs:      p,
 	}), nil


### PR DESCRIPTION
Restores compatibility with Envoy's default
settings which configure TLS 1.2 when acting
as a client.

Closes #22.