### PR TITLE
Remove reviewers from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,10 @@ updates:
     interval: "weekly"
   labels:
   - area/dependency
-  reviewers:
-  - projectcontour/maintainers
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
   labels:
   - area/tooling
-  reviewers:
-  - projectcontour/maintainers
   


### PR DESCRIPTION
See blog post describing deprecation: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Fixes #193